### PR TITLE
Change default catalog from hive to system

### DIFF
--- a/sqlalchemy_trino/dialect.py
+++ b/sqlalchemy_trino/dialect.py
@@ -75,7 +75,7 @@ class TrinoDialect(DefaultDialect):
     def create_connect_args(self, url: URL) -> Tuple[List[Any], Dict[str, Any]]:
         args, kwargs = super(TrinoDialect, self).create_connect_args(url)  # type: List[Any], Dict[str, Any]
 
-        db_parts = kwargs.pop('database', 'hive').split('/')
+        db_parts = kwargs.pop('database', 'system').split('/')
         if len(db_parts) == 1:
             kwargs['catalog'] = db_parts[0]
         elif len(db_parts) == 2:


### PR DESCRIPTION
Currently, the default catalog for creating connection string is set to
hive. This could be a problem if no catalog is specified in the connection
URL and then hive catalog is used even if it is not configured on the Trino
side.This leads to a connection error on Superset UI. To avoid this it is
better to use generic catalog such as 'system'.

Closes #13