### PR TITLE
Fix data type with timestamps and timezone

### DIFF
--- a/sqlalchemy_trino/datatype.py
+++ b/sqlalchemy_trino/datatype.py
@@ -142,7 +142,8 @@ def parse_sqltype(type_str: str) -> TypeEngine:
     elif type_name == "row":
         attr_types: Dict[str, SQLType] = {}
         for attr_str in split(type_opts):
-            name, attr_type_str = split(attr_str.strip(), delimiter=' ')
+            outputs = list(split(attr_str.strip(), delimiter=' '))
+            name, attr_type_str = outputs[:2]
             attr_type = parse_sqltype(attr_type_str)
             attr_types[name] = attr_type
         return ROW(attr_types)
@@ -156,3 +157,6 @@ def parse_sqltype(type_str: str) -> TypeEngine:
         type_kwargs = dict(timezone=type_str.endswith("with time zone"))
         return type_class(**type_kwargs)  # TODO: handle time/timestamp(p) precision
     return type_class(*type_args)
+
+if __name__ == "__main__":
+    parse_sqltype("row(min timestamp(6) with time zone, max timestamp(6) with time zone, null_count bigint)")

--- a/sqlalchemy_trino/datatype.py
+++ b/sqlalchemy_trino/datatype.py
@@ -143,7 +143,7 @@ def parse_sqltype(type_str: str) -> TypeEngine:
         attr_types: Dict[str, SQLType] = {}
         for attr_str in split(type_opts):
             outputs = list(split(attr_str.strip(), delimiter=' '))
-            name, attr_type_str = outputs[:2]
+            name, attr_type_str = outputs[0], " ".join(outputs[1:])
             attr_type = parse_sqltype(attr_type_str)
             attr_types[name] = attr_type
         return ROW(attr_types)
@@ -158,5 +158,3 @@ def parse_sqltype(type_str: str) -> TypeEngine:
         return type_class(**type_kwargs)  # TODO: handle time/timestamp(p) precision
     return type_class(*type_args)
 
-if __name__ == "__main__":
-    parse_sqltype("row(min timestamp(6) with time zone, max timestamp(6) with time zone, null_count bigint)")

--- a/tests/test_datatype_parse.py
+++ b/tests/test_datatype_parse.py
@@ -2,6 +2,7 @@ import pytest
 from assertpy import assert_that
 from sqlalchemy.sql.sqltypes import *
 from sqlalchemy.sql.type_api import TypeEngine
+
 from sqlalchemy_trino import datatype
 from sqlalchemy_trino.datatype import MAP, ROW
 
@@ -78,8 +79,8 @@ parse_row_testcases = {
     'row(a varchar(20), b decimal(20,3))': ROW(dict(a=VARCHAR(20), b=DECIMAL(20, 3))),
     'row(x array(varchar(10)), y array(array(varchar(10))), z decimal(20,3))':
         ROW(dict(x=ARRAY(VARCHAR(10)), y=ARRAY(VARCHAR(10), dimensions=2), z=DECIMAL(20, 3))),
-    'row(x timestamp(6) with time zone)':
-        ROW(dict(x=TIMESTAMP())),
+    'row(min timestamp(6) with time zone, max timestamp(6) with time zone, null_count bigint)':
+        ROW(dict(min=TIMESTAMP(), max=TIMESTAMP(), null_count=BIGINT())),
 }
 
 

--- a/tests/test_datatype_parse.py
+++ b/tests/test_datatype_parse.py
@@ -2,7 +2,6 @@ import pytest
 from assertpy import assert_that
 from sqlalchemy.sql.sqltypes import *
 from sqlalchemy.sql.type_api import TypeEngine
-
 from sqlalchemy_trino import datatype
 from sqlalchemy_trino.datatype import MAP, ROW
 
@@ -79,6 +78,8 @@ parse_row_testcases = {
     'row(a varchar(20), b decimal(20,3))': ROW(dict(a=VARCHAR(20), b=DECIMAL(20, 3))),
     'row(x array(varchar(10)), y array(array(varchar(10))), z decimal(20,3))':
         ROW(dict(x=ARRAY(VARCHAR(10)), y=ARRAY(VARCHAR(10), dimensions=2), z=DECIMAL(20, 3))),
+    'row(x timestamp(6) with time zone)':
+        ROW(dict(x=TIMESTAMP())),
 }
 
 


### PR DESCRIPTION
parsing for rows would fail with 
`row(x timestamp(6) with time zone)`

This because the driver would not expect extra parameters

Adding both a fix and a test to check if the code works