### PR TITLE
Support connection parameter sessionUser

### DIFF
--- a/sqlalchemy_trino/dialect.py
+++ b/sqlalchemy_trino/dialect.py
@@ -85,7 +85,8 @@ class TrinoDialect(DefaultDialect):
             raise ValueError(f'Unexpected database format {url.database}')
 
         username = kwargs.pop('username', 'anonymous')
-        kwargs['user'] = username
+        session_user = kwargs.pop('sessionUser', username)
+        kwargs['user'] = session_user
 
         password = kwargs.pop('password', None)
         if password:

--- a/tests/test_dialect.py
+++ b/tests/test_dialect.py
@@ -1,0 +1,21 @@
+from sqlalchemy.engine import url
+from sqlalchemy_trino.dialect import TrinoDialect
+
+
+def test_trino_connection_string_user():
+    dialect = TrinoDialect()
+    username = 'test-user'
+    u = url.make_url(f'trino://{username}@host')
+    _, cparams = dialect.create_connect_args(u)
+
+    assert cparams['user'] == username
+
+
+def test_trino_connection_string_session_user():
+    dialect = TrinoDialect()
+    username = 'test-user'
+    session_user = 'sess-user'
+    u = url.make_url(f'trino://{username}@host/?sessionUser={session_user}')
+    _, cparams = dialect.create_connect_args(u)
+
+    assert cparams['user'] == session_user


### PR DESCRIPTION
Fixes #24 

This is an optional parameter but will support impersonation where it presents both username/password and sessionUser when connecting to Trino.