### PR TITLE
Fix dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-SQLAlchemy~=1.3
+SQLAlchemy~=1.3.0
 trino~=0.305

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setuptools.setup(
     ],
     python_requires='>=3.7',
     install_requires=[
-        "sqlalchemy~=1.3",
+        "sqlalchemy~=1.3.0",
         "trino~=0.305",
     ],
     entry_points={


### PR DESCRIPTION
Fix #16

## Before

when running `pip install sqlalchemy-trino`:

```SHELL
pip install sqlalchemy-trino
Collecting sqlalchemy-trino
  Downloading sqlalchemy_trino-0.3.0-py3-none-any.whl (14 kB)
Collecting sqlalchemy~=1.3
  Downloading SQLAlchemy-1.4.23-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl (1.5 MB)
     |████████████████████████████████| 1.5 MB 1.5 MB/s 
Collecting trino~=0.305
```

## Expected result

It should install sqlalchemy 1.3.x.