### PR TITLE
improve datatype parser

### DIFF
--- a/sqlalchemy_trino/compiler.py
+++ b/sqlalchemy_trino/compiler.py
@@ -13,9 +13,11 @@ RESERVED_WORDS = {
     "create",
     "cross",
     "cube",
+    "current_catalog",
     "current_date",
     "current_path",
     "current_role",
+    "current_schema",
     "current_time",
     "current_timestamp",
     "current_user",
@@ -62,6 +64,7 @@ RESERVED_WORDS = {
     "right",
     "rollup",
     "select",
+    "skip",
     "table",
     "then",
     "true",
@@ -92,7 +95,7 @@ class TrinoTypeCompiler(compiler.GenericTypeCompiler):
         elif 32 < precision <= 64:
             return self.visit_DOUBLE(type_, **kw)
         else:
-            raise ValueError(f"type.precision={type_.precision} is invalid")
+            raise ValueError(f"type.precision must be in range [0, 64], got {type_.precision}")
 
     def visit_DOUBLE(self, type_, **kw):
         return "DOUBLE"

--- a/tests/assertions.py
+++ b/tests/assertions.py
@@ -13,6 +13,7 @@ def assert_sqltype(this: SQLType, that: SQLType):
     if isinstance(this, ARRAY):
         assert_sqltype(this.item_type, that.item_type)
         if this.dimensions is None or this.dimensions == 1:
+            # ARRAY(dimensions=None) == ARRAY(dimensions=1)
             assert_that(that.dimensions).is_in(None, 1)
         else:
             assert_that(this.dimensions).is_equal_to(this.dimensions)
@@ -21,9 +22,9 @@ def assert_sqltype(this: SQLType, that: SQLType):
         assert_sqltype(this.value_type, that.value_type)
     elif isinstance(this, ROW):
         assert_that(len(this.attr_types)).is_equal_to(len(that.attr_types))
-        for name, this_attr in this.attr_types.items():
-            that_attr = this.attr_types[name]
-            assert_sqltype(this_attr, that_attr)
+        for (this_attr, that_attr) in zip(this.attr_types, that.attr_types):
+            assert_that(this_attr[0]).is_equal_to(that_attr[0])
+            assert_sqltype(this_attr[1], that_attr[1])
     else:
         assert_that(str(this)).is_equal_to(str(that))
 


### PR DESCRIPTION
Improve `parse_sqltype` with following changes:
* rename `split` func to `aware_split`
* add `maxsplit` params which allow split type with multiple words, e.g `ts TIMESTAMP WITH TIME ZONE`
* `unquote` func which used when parse column contain special chars, e.g `row("first name" varchar, "last name" varchar)`