### PR TITLE
Release version 0.4.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setuptools.setup(
     name="sqlalchemy-trino",
-    version="0.4.0",
+    version="0.4.1",
     author="Dũng Đặng Minh",
     author_email="dungdm93@live.com",
     description="Trino dialect for SQLAlchemy",
@@ -33,7 +33,7 @@ setuptools.setup(
     python_requires='>=3.7',
     install_requires=[
         "sqlalchemy~=1.3",
-        "trino~=0.306",
+        "trino==0.306",
     ],
     entry_points={
         "sqlalchemy.dialects": [


### PR DESCRIPTION
[`trino-python-client`](https://github.com/trinodb/trino-python-client) 0.307 release with built-in SQLAlchemy driver (code donation from this repo).
To avoid conflict between this package and the built-in dialect, please update the `sqlalchemy-trino` to 0.4.1 or pinned `trino` to `0.360.0`

Start `0.5` `sqlalchemy-trino` will going to maintenance mode, and all development should going to [`trino-python-client`](https://github.com/trinodb/trino-python-client)
