### PR TITLE
Deprecated `sqlalchemy-trino` in favor of `trino-python-client`

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,3 @@
 include LICENSE
 include README.md
-recursive-include sqlalchemy_trino *
+# recursive-include sqlalchemy_trino *

--- a/README.md
+++ b/README.md
@@ -1,10 +1,13 @@
 sqlalchemy-trino
 ================
-_[Trino](https://trino.io/) (f.k.a PrestoSQL) dialect for SQLAlchemy._
 
-The primary purpose of this is provide a dialect for Trino that can be used with [Apache Superset](https://superset.apache.org/).
-But other use-cases should works as well.
-# Supported Trino version
+## ⚠️ Deprecation and Archive Notice
+`sqlalchemy-trino` was developed as _[Trino](https://trino.io/) (f.k.a PrestoSQL) dialect for SQLAlchemy._
+Since trinodb/trino-python-client#81, all code of `sqlalchemy-trino` is donated and merged into upstream project.
+So now, this project is no longer active and consider as deprecated.
+
+
+## Supported Trino version
 
 Trino version 352 and higher
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setuptools.setup(
     name="sqlalchemy-trino",
-    version="0.4.1",
+    version="0.5.0",
     author="Dũng Đặng Minh",
     author_email="dungdm93@live.com",
     description="Trino dialect for SQLAlchemy",
@@ -13,7 +13,6 @@ setuptools.setup(
     long_description_content_type="text/markdown",
     url="https://github.com/dungdm93/sqlalchemy-trino",
     keywords=["sqlalchemy", "trino"],
-    packages=["sqlalchemy_trino"],
     license="Apache 2.0",
     platforms=["any"],
     classifiers=[
@@ -32,12 +31,6 @@ setuptools.setup(
     ],
     python_requires='>=3.7',
     install_requires=[
-        "sqlalchemy~=1.3",
-        "trino==0.306",
+        "trino[sqlalchemy]>=0.310",
     ],
-    entry_points={
-        "sqlalchemy.dialects": [
-            "trino = sqlalchemy_trino.dialect:TrinoDialect",
-        ]
-    },
 )


### PR DESCRIPTION
`sqlalchemy-trino` was developed as _[Trino](https://trino.io/) (f.k.a PrestoSQL) dialect for SQLAlchemy._
Since trinodb/trino-python-client#81, all code of `sqlalchemy-trino` is donated and merged into upstream project.
So now, this project is no longer active and consider as deprecated.